### PR TITLE
SourceApp: Move Container App specification from spec to spec.app

### DIFF
--- a/src/reconcile/reconcile.go
+++ b/src/reconcile/reconcile.go
@@ -114,7 +114,7 @@ func (r *Reconciler) createOrUpdateAppsIfNeeded(ctx context.Context, sourceApps 
 	for _, name := range sourceApps.GetSortedNames() {
 		sourceApp, _ := sourceApps.Get(name)
 		remoteApp, ok := remoteApps.Get(name)
-		needsUpdate, updateReason := r.cache.NeedsUpdate(name, remoteApp.App, sourceApp.Specification)
+		needsUpdate, updateReason := r.cache.NeedsUpdate(name, remoteApp.App, sourceApp.Specification.App)
 		if !needsUpdate {
 			log.Info("skipping update, no changes", "app", name)
 			continue
@@ -124,7 +124,7 @@ func (r *Reconciler) createOrUpdateAppsIfNeeded(ctx context.Context, sourceApps 
 				return fmt.Errorf("trying to update a non-managed app: %s", name)
 			}
 
-			err := r.remoteClient.Update(ctx, name, *sourceApp.Specification)
+			err := r.remoteClient.Update(ctx, name, *sourceApp.Specification.App)
 			if err != nil {
 				return fmt.Errorf("failed to update %s: %w", name, err)
 			}
@@ -132,7 +132,7 @@ func (r *Reconciler) createOrUpdateAppsIfNeeded(ctx context.Context, sourceApps 
 			continue
 		}
 
-		err := r.remoteClient.Create(ctx, name, *sourceApp.Specification)
+		err := r.remoteClient.Create(ctx, name, *sourceApp.Specification.App)
 		if err != nil {
 			return fmt.Errorf("failed to create %s: %w", name, err)
 		}
@@ -154,7 +154,7 @@ func (r *Reconciler) updateCache(ctx context.Context, sourceApps *source.SourceA
 		if !ok {
 			return fmt.Errorf("unable to locate %s after create or update", name)
 		}
-		r.cache.Set(name, remoteApp.App, sourceApp.Specification)
+		r.cache.Set(name, remoteApp.App, sourceApp.Specification.App)
 	}
 
 	return nil

--- a/src/reconcile/reconcile_test.go
+++ b/src/reconcile/reconcile_test.go
@@ -93,7 +93,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 		}, nil)
 		remoteClient.GetFirstResponse(&remote.RemoteApps{}, nil)
@@ -118,7 +120,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 		}, nil)
 		remoteClient.GetFirstResponse(&remote.RemoteApps{}, nil)
@@ -148,7 +152,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo1",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 			"foo2": source.SourceApp{
 				Kind:       "AzureContainerApp",
@@ -156,7 +162,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo2",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 		}, nil)
 		remoteClient.GetFirstResponse(&remote.RemoteApps{}, nil)
@@ -188,7 +196,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo1",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 			"foo2": source.SourceApp{
 				Kind:       "AzureContainerApp",
@@ -196,7 +206,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo2",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 		}, nil)
 		remoteClient.GetFirstResponse(&remote.RemoteApps{}, nil)
@@ -232,7 +244,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo1",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 		}, nil)
 		remoteClient.GetFirstResponse(&remote.RemoteApps{
@@ -274,8 +288,10 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo1",
 				},
-				Specification: &armappcontainers.ContainerApp{},
-				Err:           fmt.Errorf("foobar"),
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
+				Err: fmt.Errorf("foobar"),
 			},
 		}, nil)
 		remoteClient.GetFirstResponse(&remote.RemoteApps{
@@ -314,8 +330,10 @@ func TestReconciler(t *testing.T) {
 			Metadata: map[string]string{
 				"name": "foo1",
 			},
-			Specification: &armappcontainers.ContainerApp{
-				Name: toPtr("foo1"),
+			Specification: &source.SourceAppSpecification{
+				App: &armappcontainers.ContainerApp{
+					Name: toPtr("foo1"),
+				},
 			},
 		}
 		sourceApp1Updated := source.SourceApp{
@@ -324,10 +342,12 @@ func TestReconciler(t *testing.T) {
 			Metadata: map[string]string{
 				"name": "foo1",
 			},
-			Specification: &armappcontainers.ContainerApp{
-				Name: toPtr("foo1"),
-				Tags: map[string]*string{
-					"foo": toPtr("bar"),
+			Specification: &source.SourceAppSpecification{
+				App: &armappcontainers.ContainerApp{
+					Name: toPtr("foo1"),
+					Tags: map[string]*string{
+						"foo": toPtr("bar"),
+					},
 				},
 			},
 		}
@@ -470,7 +490,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo1",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 		}, nil)
 		remoteClient.GetFirstResponse(&remote.RemoteApps{
@@ -497,7 +519,9 @@ func TestReconciler(t *testing.T) {
 				Metadata: map[string]string{
 					"name": "foo1",
 				},
-				Specification: &armappcontainers.ContainerApp{},
+				Specification: &source.SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{},
+				},
 			},
 		}, nil)
 		remoteClient.GetFirstResponse(&remote.RemoteApps{}, nil)

--- a/src/source/app_test.go
+++ b/src/source/app_test.go
@@ -56,7 +56,8 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
   name: foo
 spec:
-  location: foobar
+  app:
+    location: foobar
 `,
 			expectedResult: SourceApp{
 				Kind:       "AzureContainerApp",
@@ -64,10 +65,12 @@ spec:
 				Metadata: map[string]string{
 					"name": "foo",
 				},
-				Specification: &armappcontainers.ContainerApp{
-					Location: toPtr("foobar"),
-					Tags: map[string]*string{
-						"aca.xenit.io": toPtr("true"),
+				Specification: &SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{
+						Location: toPtr("foobar"),
+						Tags: map[string]*string{
+							"aca.xenit.io": toPtr("true"),
+						},
 					},
 				},
 			},
@@ -81,7 +84,8 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
   name: foo
 spec:
-  foobar: baz
+  app:
+    foobar: baz
 `,
 			expectedResult: SourceApp{},
 			expectedError:  "json: unknown field \"foobar\"",
@@ -94,20 +98,21 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
   name: foo
 spec:
-  location: foobar
-  properties:
-    configuration:
-      activeRevisionsMode: Single
-    template:
-      containers:
-      - name: simple-hello-world-container
-        image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
-        resources:
-          cpu: 0.25
-          memory: .5Gi
-      scale:
-        minReplicas: 1
-        maxReplicas: 1
+  app:
+    location: foobar
+    properties:
+      configuration:
+        activeRevisionsMode: Single
+      template:
+        containers:
+        - name: simple-hello-world-container
+          image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
+          resources:
+            cpu: 0.25
+            memory: .5Gi
+        scale:
+          minReplicas: 1
+          maxReplicas: 1
 `,
 			expectedResult: SourceApp{
 				Kind:       "AzureContainerApp",
@@ -115,30 +120,32 @@ spec:
 				Metadata: map[string]string{
 					"name": "foo",
 				},
-				Specification: &armappcontainers.ContainerApp{
-					Location: toPtr("foobar"),
-					Tags: map[string]*string{
-						"aca.xenit.io": toPtr("true"),
-					},
-					Identity: nil,
-					Properties: &armappcontainers.ContainerAppProperties{
-						Configuration: &armappcontainers.Configuration{
-							ActiveRevisionsMode: toPtr(armappcontainers.ActiveRevisionsModeSingle),
+				Specification: &SourceAppSpecification{
+					App: &armappcontainers.ContainerApp{
+						Location: toPtr("foobar"),
+						Tags: map[string]*string{
+							"aca.xenit.io": toPtr("true"),
 						},
-						Template: &armappcontainers.Template{
-							Containers: []*armappcontainers.Container{
-								{
-									Name:  toPtr("simple-hello-world-container"),
-									Image: toPtr("mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"),
-									Resources: &armappcontainers.ContainerResources{
-										CPU:    toPtr(float64(0.25)),
-										Memory: toPtr(".5Gi"),
+						Identity: nil,
+						Properties: &armappcontainers.ContainerAppProperties{
+							Configuration: &armappcontainers.Configuration{
+								ActiveRevisionsMode: toPtr(armappcontainers.ActiveRevisionsModeSingle),
+							},
+							Template: &armappcontainers.Template{
+								Containers: []*armappcontainers.Container{
+									{
+										Name:  toPtr("simple-hello-world-container"),
+										Image: toPtr("mcr.microsoft.com/azuredocs/containerapps-helloworld:latest"),
+										Resources: &armappcontainers.ContainerResources{
+											CPU:    toPtr(float64(0.25)),
+											Memory: toPtr(".5Gi"),
+										},
 									},
 								},
-							},
-							Scale: &armappcontainers.Scale{
-								MaxReplicas: toPtr(int32(1)),
-								MinReplicas: toPtr(int32(1)),
+								Scale: &armappcontainers.Scale{
+									MaxReplicas: toPtr(int32(1)),
+									MinReplicas: toPtr(int32(1)),
+								},
 							},
 						},
 					},
@@ -178,7 +185,8 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
  name: foo
 spec:
-  location: foobar
+  app:
+    location: foobar
 `,
 			expectedResult: SourceApps{
 				"foo": {
@@ -187,10 +195,12 @@ spec:
 					Metadata: map[string]string{
 						"name": "foo",
 					},
-					Specification: &armappcontainers.ContainerApp{
-						Location: toPtr("foobar"),
-						Tags: map[string]*string{
-							"aca.xenit.io": toPtr("true"),
+					Specification: &SourceAppSpecification{
+						App: &armappcontainers.ContainerApp{
+							Location: toPtr("foobar"),
+							Tags: map[string]*string{
+								"aca.xenit.io": toPtr("true"),
+							},
 						},
 					},
 				},
@@ -206,14 +216,16 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
  name: foo
 spec:
-  location: foobar
+  app:
+    location: foobar
 ---
 kind: AzureContainerApp
 apiVersion: aca.xenit.io/v1alpha1
 metadata:
  name: bar
 spec:
-  location: foobar
+  app:
+    location: foobar
 `,
 			expectedResult: SourceApps{
 				"foo": {
@@ -222,10 +234,12 @@ spec:
 					Metadata: map[string]string{
 						"name": "foo",
 					},
-					Specification: &armappcontainers.ContainerApp{
-						Location: toPtr("foobar"),
-						Tags: map[string]*string{
-							"aca.xenit.io": toPtr("true"),
+					Specification: &SourceAppSpecification{
+						App: &armappcontainers.ContainerApp{
+							Location: toPtr("foobar"),
+							Tags: map[string]*string{
+								"aca.xenit.io": toPtr("true"),
+							},
 						},
 					},
 				},
@@ -235,10 +249,12 @@ spec:
 					Metadata: map[string]string{
 						"name": "bar",
 					},
-					Specification: &armappcontainers.ContainerApp{
-						Location: toPtr("foobar"),
-						Tags: map[string]*string{
-							"aca.xenit.io": toPtr("true"),
+					Specification: &SourceAppSpecification{
+						App: &armappcontainers.ContainerApp{
+							Location: toPtr("foobar"),
+							Tags: map[string]*string{
+								"aca.xenit.io": toPtr("true"),
+							},
 						},
 					},
 				},
@@ -254,14 +270,16 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
  name: foo
 spec:
-  location: foobar
+  app:
+    location: foobar
 ---
 kind: foobar
 apiVersion: aca.xenit.io/v1alpha1
 metadata:
  name: bar
 spec:
-  location: foobar
+  app:
+    location: foobar
 `,
 			expectedResult: SourceApps{
 				"foo": {
@@ -270,10 +288,12 @@ spec:
 					Metadata: map[string]string{
 						"name": "foo",
 					},
-					Specification: &armappcontainers.ContainerApp{
-						Location: toPtr("foobar"),
-						Tags: map[string]*string{
-							"aca.xenit.io": toPtr("true"),
+					Specification: &SourceAppSpecification{
+						App: &armappcontainers.ContainerApp{
+							Location: toPtr("foobar"),
+							Tags: map[string]*string{
+								"aca.xenit.io": toPtr("true"),
+							},
 						},
 					},
 				},

--- a/test/yaml/example1.yaml
+++ b/test/yaml/example1.yaml
@@ -3,37 +3,39 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
   name: foo1
 spec:
-  location: west europe
-  properties:
-    configuration:
-      activeRevisionsMode: Single
-    template:
-      containers:
-      - name: simple-hello-world-container
-        image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
-        resources:
-          cpu: 0.25
-          memory: .5Gi
-      scale:
-        minReplicas: 2
-        maxReplicas: 2
+  app:
+    location: west europe
+    properties:
+      configuration:
+        activeRevisionsMode: Single
+      template:
+        containers:
+        - name: simple-hello-world-container
+          image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
+          resources:
+            cpu: 0.25
+            memory: .5Gi
+        scale:
+          minReplicas: 2
+          maxReplicas: 2
 ---
 kind: AzureContainerApp
 apiVersion: aca.xenit.io/v1alpha1
 metadata:
   name: foo2
 spec:
-  location: west europe
-  properties:
-    configuration:
-      activeRevisionsMode: Single
-    template:
-      containers:
-      - name: simple-hello-world-container
-        image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
-        resources:
-          cpu: 0.25
-          memory: .5Gi
-      scale:
-        minReplicas: 2
-        maxReplicas: 2
+  app:
+    location: west europe
+    properties:
+      configuration:
+        activeRevisionsMode: Single
+      template:
+        containers:
+        - name: simple-hello-world-container
+          image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
+          resources:
+            cpu: 0.25
+            memory: .5Gi
+        scale:
+          minReplicas: 2
+          maxReplicas: 2

--- a/test/yaml/example2.yaml
+++ b/test/yaml/example2.yaml
@@ -3,17 +3,18 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
   name: foo3
 spec:
-  location: west europe
-  properties:
-    configuration:
-      activeRevisionsMode: Single
-    template:
-      containers:
-      - name: simple-hello-world-container
-        image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
-        resources:
-          cpu: 0.25
-          memory: .5Gi
-      scale:
-        minReplicas: 2
-        maxReplicas: 2
+  app:
+    location: west europe
+    properties:
+      configuration:
+        activeRevisionsMode: Single
+      template:
+        containers:
+        - name: simple-hello-world-container
+          image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
+          resources:
+            cpu: 0.25
+            memory: .5Gi
+        scale:
+          minReplicas: 2
+          maxReplicas: 2

--- a/test/yaml/foo/example3.yaml
+++ b/test/yaml/foo/example3.yaml
@@ -3,17 +3,18 @@ apiVersion: aca.xenit.io/v1alpha1
 metadata:
   name: foo4
 spec:
-  location: west europe
-  properties:
-    configuration:
-      activeRevisionsMode: Single
-    template:
-      containers:
-      - name: simple-hello-world-container
-        image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
-        resources:
-          cpu: 0.25
-          memory: .5Gi
-      scale:
-        minReplicas: 2
-        maxReplicas: 2
+  app:
+    location: west europe
+    properties:
+      configuration:
+        activeRevisionsMode: Single
+      template:
+        containers:
+        - name: simple-hello-world-container
+          image: mcr.microsoft.com/azuredocs/containerapps-helloworld:latest
+          resources:
+            cpu: 0.25
+            memory: .5Gi
+        scale:
+          minReplicas: 2
+          maxReplicas: 2


### PR DESCRIPTION
This is to make it possible to use things like spec.secret to extract
secrets from something like keyvault during reconciliation.