### PR TITLE
GitHub has a 140 character limit on description

### DIFF
--- a/src/notification/github.go
+++ b/src/notification/github.go
@@ -63,11 +63,10 @@ func (g *GitHubNotification) Send(ctx context.Context, event NotificationEvent) 
 	if err != nil {
 		return err
 	}
-
 	status := &github.RepoStatus{
 		State:       &state,
 		Context:     &event.Name,
-		Description: &event.Description,
+		Description: toGitHubDescription(event.Description),
 	}
 
 	opts := &github.ListOptions{PerPage: 50}
@@ -85,6 +84,15 @@ func (g *GitHubNotification) Send(ctx context.Context, event NotificationEvent) 
 	}
 
 	return nil
+}
+
+func toGitHubDescription(description string) *string {
+	if len(description) <= 140 {
+		return &description
+	}
+
+	strippedDescription := description[0:140]
+	return &strippedDescription
 }
 
 func toGitHubState(state NotificationState) (string, error) {

--- a/src/notification/github_test.go
+++ b/src/notification/github_test.go
@@ -1,0 +1,36 @@
+package notification
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestToGitHubDescription(t *testing.T) {
+	cases := []struct {
+		input          string
+		expectedResult string
+	}{
+		{
+			input:          "",
+			expectedResult: "",
+		},
+		{
+			input:          "foobar",
+			expectedResult: "foobar",
+		},
+		{
+			input:          "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et ma",
+			expectedResult: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et ma",
+		},
+		{
+			input:          "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et magnis dis parturient montes, nascetur ridiculus mus. Donec qu",
+			expectedResult: "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo ligula eget dolor. Aenean massa. Cum sociis natoque penatibus et ma",
+		},
+	}
+
+	for _, c := range cases {
+		result := toGitHubDescription(c.input)
+		require.Equal(t, c.expectedResult, *result)
+	}
+}


### PR DESCRIPTION
This PR introduces a fix that will limit the description sent to GitHub to 140 characters.