### PR TITLE
add small k6 load test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,3 +76,6 @@ docker-run: docker-build
 		--git-url $${GIT_URL_AND_CREDS} \
 		--git-branch "main" \
 		--git-yaml-path "yaml/"
+
+k6-http-get:
+	k6 run -e LOAD_TEST_URI=$${LOAD_TEST_URI} test/k6/http_get.js

--- a/test/k6/http_get.js
+++ b/test/k6/http_get.js
@@ -1,0 +1,14 @@
+import { check } from "k6";
+import http from "k6/http";
+
+export const options = {
+  vus: 10,
+  duration: "2m",
+};
+
+export default function () {
+  const res = http.get(__ENV.LOAD_TEST_URI);
+  check(res, {
+    "is status 200": (r) => r.status === 200,
+  });
+}


### PR DESCRIPTION
Fixes #31 

We've verified that we can run a load test using k6 and will get correct responses during an image update using azcagit. 10 virtual users / 2 minutes where the update is made during the run. Tested both with and without updating the image.

Just to be sure, we ran a negative test to see that our expect works as we expect.